### PR TITLE
Added a Trajectory structure to improve the user utilisation

### DIFF
--- a/examples/collision_avoid.rs
+++ b/examples/collision_avoid.rs
@@ -30,6 +30,7 @@ use ncollide::ncollide_geometry::query::Proximity;
 
 use rand::distributions::{IndependentSample, Range};
 
+use rrt::Trajectory;
 
 struct CollisionProblem {
     obstacle: Cuboid<na::Vector3<f32>>,
@@ -99,10 +100,10 @@ fn main() {
 
     cs.set_local_transformation(poss);
     cg.set_local_transformation(posg);
-    let mut path = vec![];
+    let mut path = Trajectory{waypoints: vec![]};
     let mut index = 0;
     while window.render() {
-        if index == path.len() {
+        if index == path.waypoints.len() {
             path = rrt::dual_rrt_connect(
                 &start,
                 &goal,
@@ -111,10 +112,10 @@ fn main() {
                 0.05,
                 1000,
             ).unwrap();
-            rrt::smooth_path(&mut path, |x: &[f64]| p.is_feasible(x), 0.05, 100);
+            rrt::smooth_path(&mut path.waypoints, |x: &[f64]| p.is_feasible(x), 0.05, 100);
             index = 0;
         }
-        let point = &path[index % path.len()];
+        let point = &path.waypoints[index % path.waypoints.len()];
         let pos = Isometry3::new(
             Vector3::new(point[0] as f32, point[1] as f32, point[2] as f32),
             na::zero(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@
 //!                                     0.2,
 //!                                     1000)
 //!               .unwrap();
-//!   println!("{:?}", result);
-//!   assert!(result.len() >= 4);
+//!   println!("{:?}", result.waypoints);
+//!   assert!(result.waypoints.len() >= 4);
 //! }
 //! ```
 extern crate kdtree;
@@ -51,6 +51,10 @@ extern crate rand;
 use kdtree::distance::squared_euclidean;
 use std::mem;
 use rand::distributions::{IndependentSample, Range};
+
+pub struct Trajectory {
+    pub waypoints: Vec<Vec<f64>>,
+}
 
 pub enum ExtendStatus {
     Reached(usize),
@@ -180,7 +184,7 @@ pub fn dual_rrt_connect<FF, FR>(
     random_sample: FR,
     extend_length: f64,
     num_max_try: usize,
-) -> Result<Vec<Vec<f64>>, String>
+) -> Result<Trajectory, String>
 where
     FF: FnMut(&[f64]) -> bool,
     FR: Fn() -> Vec<f64>,
@@ -209,7 +213,7 @@ where
                     if tree_b.name == "start" {
                         a_all.reverse();
                     }
-                    return Ok(a_all);
+                    return Ok(Trajectory{waypoints: a_all});
                 }
             }
         }
@@ -288,14 +292,14 @@ fn it_works() {
         0.2,
         1000,
     ).unwrap();
-    println!("{:?}", result);
-    assert!(result.len() >= 4);
+    println!("{:?}", result.waypoints);
+    assert!(result.waypoints.len() >= 4);
     smooth_path(
-        &mut result,
+        &mut result.waypoints,
         |p: &[f64]| !(p[0].abs() < 1.0 && p[1].abs() < 1.0),
         0.2,
         100,
     );
-    println!("{:?}", result);
-    assert!(result.len() >= 3);
+    println!("{:?}", result.waypoints);
+    assert!(result.waypoints.len() >= 3);
 }


### PR DESCRIPTION
I think it is important for the user to have many different information when computing a trajectory. For example it could be useful to know the length (in cartesian space) of the trajectory, or the cost of a trajectory, or the smoothness.

To allow it we need to have a Trajectory structure that can give all of these information . I just created the structure and put the Vec<Vec<f64>> behing the "waypoints" attribute but if you think this is a good idea we can then extend it to something with more information.

By the way, I would be interested to create a crate for motion planning in Rust by first starting to modify your crate and then extending it to allow multiple motion planners, would you be interested ?