### PR TITLE
upgrade to nalgebra 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 
 [dependencies]
 kdtree = "0.5.1"
-rand = "0.3.15"
+rand = "0.4"
 log = "0.3.8"
 env_logger = "0.4.3"
 num-traits = "0.2"
 
 [dev-dependencies]
-nalgebra = "0.13.0"
-ncollide = "0.13.0"
-kiss3d = "0.11.0"
+nalgebra = "0.14"
+ncollide = "0.14.1"
+kiss3d = "0.14"


### PR DESCRIPTION
The latest ncollide is compatible with 0.14, so I have stopped there. Fortunately this already helps with rust-lang/rust#49799